### PR TITLE
client.readStatus shouldn't die if there are no indexes on the server…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ group: deprecated-2017Q2
 services:
   - docker
 before_install:
-  - docker run -d -p 10101:10101 pilosa/pilosa:v0.4.0
+  - docker run -d -p 10101:10101 pilosa/pilosa:v0.5.0
 script:
   - mvn -f com.pilosa.client/pom.xml clean test failsafe:integration-test jacoco:report coveralls:report
 

--- a/com.pilosa.client/pom.xml
+++ b/com.pilosa.client/pom.xml
@@ -40,7 +40,7 @@
 
     <groupId>com.pilosa</groupId>
     <artifactId>pilosa-client</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/com.pilosa.client/src/test/java/com/pilosa/client/status/NodeInfoTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/status/NodeInfoTest.java
@@ -34,30 +34,21 @@
 
 package com.pilosa.client.status;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pilosa.client.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class NodeInfo {
-    @JsonProperty("Host")
-    public String getHost() {
-        return this.host;
-    }
+import static org.junit.Assert.assertEquals;
 
-    void setHost(String host) {
-        this.host = host;
+@Category(UnitTest.class)
+public class NodeInfoTest {
+    @Test
+    public void testNodeInfoReturnsEmptyIndexesArrayIfNotSet() {
+        NodeInfo nodeInfo = new NodeInfo();
+        List<IndexInfo> target = new ArrayList<>();
+        assertEquals(target, nodeInfo.getIndexes());
     }
-
-    @JsonProperty("Indexes")
-    public List<IndexInfo> getIndexes() {
-        return this.indexes;
-    }
-
-    void setIndexes(List<IndexInfo> indexes) {
-        this.indexes = indexes;
-    }
-
-    private String host;
-    private List<IndexInfo> indexes = new ArrayList<>();
 }


### PR DESCRIPTION
…. Updated .travis.yml to use Pilosa v0.5.0.