### PR TITLE
Mass update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,15 @@ jdk:
     - oraclejdk8
 sudo: required
 before_install:
+  - openssl req -x509 -newkey rsa:4096 -keyout test.pilosa.local.key -out test.pilosa.local.crt -days 3650 -nodes -subj "/C=US/ST=Texas/L=Austin/O=Pilosa/OU=Com/CN=test.pilosa.local"
   - wget https://s3.amazonaws.com/build.pilosa.com/pilosa-master-linux-amd64.tar.gz && tar xf pilosa-master-linux-amd64.tar.gz
-  - ./pilosa-master-linux-amd64/pilosa server &
+  - ./pilosa-master-linux-amd64/pilosa server -d http_data &
+  - ./pilosa-master-linux-amd64/pilosa server -b https://:20101 -d https_data --tls.skip-verify --tls.certificate test.pilosa.local.crt --tls.key test.pilosa.local.key --cluster.type static &
   - wget http://www-us.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz
   - tar xf apache-maven-3.5.0-bin.tar.gz
   - export M2_HOME=$PWD/apache-maven-3.5.0
   - export PATH=$M2_HOME/bin:$PATH
 script:
+  - PILOSA_BIND="https://:20101" make test-all
   - mvn -f com.pilosa.client/pom.xml clean test failsafe:integration-test jacoco:report coveralls:report
 

--- a/com.pilosa.client/src/integration-test/java/integrationtest/InsecurePilosaClientIT.java
+++ b/com.pilosa.client/src/integration-test/java/integrationtest/InsecurePilosaClientIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Pilosa Corp.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+package integrationtest;
+
+import com.pilosa.client.ClientOptions;
+import com.pilosa.client.Cluster;
+import com.pilosa.client.PilosaClient;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.ssl.SSLContextBuilder;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public class InsecurePilosaClientIT extends PilosaClient {
+
+    public InsecurePilosaClientIT(Cluster cluster, ClientOptions options) {
+        super(cluster, options);
+    }
+
+    @Override
+    protected Registry<ConnectionSocketFactory> getRegistry() {
+        HostnameVerifier verifier = new HostnameVerifier() {
+            @Override
+            public boolean verify(String hostName, SSLSession session) {
+                return true;
+            }
+        };
+
+        SSLContext sslContext = null;
+        try {
+            sslContext = new SSLContextBuilder().loadTrustMaterial(null, new TrustStrategy() {
+                public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+                    return true;
+                }
+            }).build();
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+            e.printStackTrace();
+        }
+        if (sslContext == null) {
+            throw new RuntimeException("SSL Context not created");
+        }
+
+        SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(
+                sslContext,
+                new String[]{"TLSv1.2"}, null, verifier);
+        return RegistryBuilder.<ConnectionSocketFactory>create()
+                .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                .register("https", sslConnectionSocketFactory)
+                .build();
+    }
+}

--- a/com.pilosa.client/src/integration-test/java/integrationtest/PilosaClientIT.java
+++ b/com.pilosa.client/src/integration-test/java/integrationtest/PilosaClientIT.java
@@ -345,8 +345,8 @@ public class PilosaClientIT {
                     frame.setBit(20, 5),
                     frame.setBit(30, 5)
             ));
-            // XXX: The following is required to make this test pass. See: https://github.com/pilosa/pilosa/issues/625
-            Thread.sleep(10000);
+            // The following is required to make this test pass. See: https://github.com/pilosa/pilosa/issues/625
+            client.httpRequest("POST", "/recalculate-caches");
             QueryResponse response = client.query(frame.topN(2));
             List<CountResultItem> items = response.getResult().getCountItems();
             assertEquals(2, items.size());

--- a/com.pilosa.client/src/integration-test/java/integrationtest/PilosaClientIT.java
+++ b/com.pilosa.client/src/integration-test/java/integrationtest/PilosaClientIT.java
@@ -77,7 +77,6 @@ public class PilosaClientIT {
     private Index colIndex;
     private Index index;
     private Frame frame;
-    private final static String SERVER_ADDRESS = ":10101";
 
     @Before
     public void setUp() throws IOException {
@@ -554,6 +553,13 @@ public class PilosaClientIT {
         }
     }
 
+    @Test
+    public void httpRequestTest() throws IOException {
+        try (PilosaClient client = getClient()) {
+            client.httpRequest("GET", "/status");
+        }
+    }
+
     @Test(expected = PilosaException.class)
     public void importFailNot200() throws IOException {
         HttpServer server = runImportFailsHttpServer();
@@ -695,6 +701,10 @@ public class PilosaClientIT {
     }
 
     private PilosaClient getClient() {
+        String bindAddress = System.getenv("PILOSA_BIND");
+        if (bindAddress == null) {
+            bindAddress = "http://:10101";
+        }
         SSLContext sslContext;
         try {
             sslContext = new SSLContextBuilder().loadTrustMaterial(null, new TrustStrategy() {
@@ -709,7 +719,7 @@ public class PilosaClientIT {
         if (sslContext != null) {
             optionsBuilder.setSslContext(sslContext);
         }
-        Cluster cluster = Cluster.withHost(URI.address(SERVER_ADDRESS));
+        Cluster cluster = Cluster.withHost(URI.address(bindAddress));
         return PilosaClient.withCluster(cluster, optionsBuilder.build());
     }
 

--- a/com.pilosa.client/src/test/java/com/pilosa/client/ClientOptionsTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/ClientOptionsTest.java
@@ -34,8 +34,13 @@
 
 package com.pilosa.client;
 
+import org.apache.http.ssl.SSLContextBuilder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -52,18 +57,21 @@ public class ClientOptionsTest {
     }
 
     @Test
-    public void testCreate() {
+    public void testCreate() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext sslContext = new SSLContextBuilder().build();
         ClientOptions options = ClientOptions.builder()
                 .setConnectionPoolSizePerRoute(2)
                 .setConnectionPoolTotalSize(50)
                 .setConnectTimeout(100)
                 .setSocketTimeout(1000)
                 .setRetryCount(5)
+                .setSslContext(sslContext)
                 .build();
         assertEquals(2, options.getConnectionPoolSizePerRoute());
         assertEquals(50, options.getConnectionPoolTotalSize());
         assertEquals(100, options.getConnectTimeout());
         assertEquals(1000, options.getSocketTimeout());
         assertEquals(5, options.getRetryCount());
+        assertEquals(sslContext, options.getSslContext());
     }
 }

--- a/com.pilosa.client/src/test/java/com/pilosa/client/PilosaClientTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/PilosaClientTest.java
@@ -106,7 +106,7 @@ public class PilosaClientTest {
     @Test(expected = IllegalArgumentException.class)
     public void invalidMethodTest() {
         PilosaClient client = PilosaClient.defaultClient();
-        client.makeRequest("INVALID", "/foo", null);
+        client.makeRequest("INVALID", "/foo", null, null);
     }
 
     @Test


### PR DESCRIPTION
- Added custom Pilosa server address support for running tests.
- Updated travis config to run tests using https too.
- Added `client.httpRequest` function which sends an HTTP request to a Pilosa server.
- Using `/recalculate-caches` endpoint to decrease integration test times by 2 * 10 secs.