### PR TITLE
Add support for slices in QueryOptions.

### DIFF
--- a/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
@@ -176,6 +176,7 @@ public class PilosaClient implements AutoCloseable {
         request.setRetrieveColumnAttributes(options.isColumns());
         request.setExcludeAttributes(options.isExcludeAttributes());
         request.setExcludeBits(options.isExcludeBits());
+        request.setSlices(options.getSlices());
         request.setQuery(query.serialize());
         return queryPath(request);
     }
@@ -704,6 +705,7 @@ class QueryRequest {
     private boolean retrieveColumnAttributes = false;
     private boolean excludeBits = false;
     private boolean excludeAttributes = false;
+    private List<Long> slices = new ArrayList<Long>();
 
     private QueryRequest(Index index) {
         this.index = index;
@@ -743,12 +745,17 @@ class QueryRequest {
         this.excludeAttributes = excludeAttributes;
     }
 
+    public void setSlices(List<Long> slices) {
+        this.slices = slices;
+    }
+
     Internal.QueryRequest toProtobuf() {
         return Internal.QueryRequest.newBuilder()
                 .setQuery(this.query)
                 .setColumnAttrs(this.retrieveColumnAttributes)
                 .setExcludeBits(this.excludeBits)
                 .setExcludeAttrs(this.excludeAttributes)
+                .addAllSlices(this.slices)
                 .build();
     }
 }

--- a/com.pilosa.client/src/main/java/com/pilosa/client/QueryOptions.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/QueryOptions.java
@@ -36,6 +36,8 @@ package com.pilosa.client;
 
 import com.pilosa.client.orm.PqlQuery;
 
+import java.util.*;
+
 /**
  * Contains options to customize {@link PilosaClient#query(PqlQuery, QueryOptions)}.
  * <p>
@@ -90,17 +92,29 @@ public class QueryOptions {
         }
 
         /**
+         * Restricts query to a subset of slices.
+         *
+         * @param slices set to a list of slices to restrict query to.
+         * @return QueryOptions builder
+         */
+        public Builder setSlices(List<Long> slices) {
+            this.slices = slices;
+            return this;
+        }
+
+        /**
          * Creates the QueryOptions object.
          *
          * @return QueryOptions object
          */
         public QueryOptions build() {
-            return new QueryOptions(this.columns, this.excludeBits, this.excludeAttributes);
+            return new QueryOptions(this.columns, this.excludeBits, this.excludeAttributes, this.slices);
         }
 
         private boolean columns = false;
         private boolean excludeBits;
         private boolean excludeAttributes;
+        private List<Long> slices = new ArrayList<Long>();
     }
 
     /**
@@ -125,6 +139,10 @@ public class QueryOptions {
         return this.excludeAttributes;
     }
 
+    public List<Long> getSlices() {
+        return this.slices;
+    }
+
     /**
      * Creates a QueryOptions.Builder object.
      * @return a Builder object
@@ -133,13 +151,15 @@ public class QueryOptions {
         return new Builder();
     }
 
-    private QueryOptions(boolean columns, boolean excludeBits, boolean excludeAttributes) {
+    private QueryOptions(boolean columns, boolean excludeBits, boolean excludeAttributes, List<Long> slices) {
         this.columns = columns;
         this.excludeBits = excludeBits;
         this.excludeAttributes = excludeAttributes;
+        this.slices = slices;
     }
 
     private final boolean columns;
     private final boolean excludeBits;
     private final boolean excludeAttributes;
+    private final List<Long> slices;
 }


### PR DESCRIPTION
This commit adds support for specifying individual slices when executing a query:

	List<Long> slices = Arrays.asList(0L, 3L);
	QueryOptions options = QueryOptions.builder()
		.setSlices(slices)
		.build();
	QueryResponse response = client.query(bitmap, options);

Fixes https://github.com/pilosa/pilosa/issues/641