### PR TITLE
Reuse ObjectMapper on nodes parsing.

### DIFF
--- a/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
@@ -616,7 +616,6 @@ public class PilosaClient implements AutoCloseable {
             HttpEntity entity = response.getEntity();
             if (entity != null) {
                 try (InputStream src = response.getEntity().getContent()) {
-                    ObjectMapper mapper = new ObjectMapper();
                     return mapper.readValue(src, new TypeReference<List<FragmentNode>>() {
                     });
                 }
@@ -681,12 +680,15 @@ public class PilosaClient implements AutoCloseable {
     }
 
     static {
+        mapper = new ObjectMapper();
+
         protobufHeaders = new Header[]{
                 new BasicHeader("Content-Type", "application/x-protobuf"),
                 new BasicHeader("Accept", "application/x-protobuf")
         };
     }
 
+    private static final ObjectMapper mapper;
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
     private static final int MAX_HOSTS = 10;


### PR DESCRIPTION
The instantiation of ObjectMapper is really expensive and time consuming.
On this PR we reuse the same instance (as in StatusMessage class) to improve performance fetching nodes.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>