### PR TITLE
Fix Column create for Key Column Values

### DIFF
--- a/com.pilosa.client/src/main/java/com/pilosa/client/Column.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/Column.java
@@ -49,11 +49,11 @@ public class Column implements Record {
     }
 
     public static Column create(long rowID, String columnKey) {
-        return create(rowID, 0, columnKey, "", 0);
+        return create(rowID, 0, "", columnKey, 0);
     }
 
     public static Column create(long rowID, String columnKey, long timestamp) {
-        return create(rowID, 0, columnKey, "", timestamp);
+        return create(rowID, 0, "", columnKey, timestamp);
     }
 
     public static Column create(String rowKey, long columnID) {

--- a/com.pilosa.client/src/test/java/com/pilosa/client/ColumnTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/ColumnTest.java
@@ -51,9 +51,9 @@ public class ColumnTest {
         compare(column, 1, 100, "", "", 65000);
 
         column = Column.create(1, "bar");
-        compare(column, 1, 0, "bar", "", 0);
+        compare(column, 1, 0, "", "bar", 0);
         column = Column.create(1, "bar", 65000);
-        compare(column, 1, 0, "bar", "", 65000);
+        compare(column, 1, 0, "", "bar", 65000);
 
         column = Column.create("foo", 100);
         compare(column, 0, 100, "foo", "", 0);


### PR DESCRIPTION
The column key values passed to the following `create` methods are incorrectly getting set to the `rowKey` variable. 

```
    public static Column create(long rowID, String columnKey) {
        return create(rowID, 0, columnKey, "", 0);
    }

    public static Column create(long rowID, String columnKey, long timestamp) {
        return create(rowID, 0, columnKey, "", timestamp);
    }
```

For comparison, method signature for the `create` method is the following. 

```
    private static Column create(long rowID, long columnID, String rowKey, String columnKey, long timestamp)
```

This pull request switches the order of the arguments so the column key gets set properly.