### PR TITLE
Including Index Options in Schema Read from Server

### DIFF
--- a/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
@@ -341,7 +341,7 @@ public class PilosaClient implements AutoCloseable {
         Schema result = Schema.defaultSchema();
         SchemaInfo schema = readServerSchema();
         for (IndexInfo indexInfo : schema.getIndexes()) {
-            Index index = result.index(indexInfo.getName());
+            Index index = result.index(indexInfo.getName(), indexInfo.getIndexOptions());
             List<FieldInfo> fields = indexInfo.getFields();
             if (fields != null) {
                 for (IFieldInfo fieldInfo : indexInfo.getFields()) {

--- a/com.pilosa.client/src/main/java/com/pilosa/client/orm/Index.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/orm/Index.java
@@ -318,7 +318,8 @@ public class Index {
         }
         Index rhs = (Index) obj;
         return rhs.name.equals(this.name) &&
-                rhs.fields.equals(this.fields);
+                rhs.fields.equals(this.fields) &&
+                rhs.getOptions().equals(this.options);
     }
 
     @Override

--- a/com.pilosa.client/src/main/java/com/pilosa/client/orm/IndexOptions.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/orm/IndexOptions.java
@@ -34,6 +34,7 @@
 
 package com.pilosa.client.orm;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -158,7 +159,8 @@ public final class IndexOptions {
                 .toHashCode();
     }
 
-    private IndexOptions(final boolean keys, Boolean trackExistence) {
+    private IndexOptions(@JsonProperty("keys") final boolean keys,
+        @JsonProperty("trackExistence") Boolean trackExistence) {
         this.keys = keys;
         this.trackExistence = trackExistence;
     }
@@ -170,6 +172,6 @@ public final class IndexOptions {
     }
 
     private static final ObjectMapper mapper;
-    private final boolean keys;
-    private final Boolean trackExistence;
+    private  boolean keys;
+    private  Boolean trackExistence;
 }

--- a/com.pilosa.client/src/main/java/com/pilosa/client/orm/Schema.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/orm/Schema.java
@@ -83,7 +83,7 @@ public class Schema {
      * @return copied index
      */
     public Index index(Index other) {
-        Index index = this.index(other.getName());
+        Index index = this.index(other.getName(), other.getOptions());
         for (Map.Entry<String, Field> fieldEntry : index.getFields().entrySet()) {
             Field field = fieldEntry.getValue();
             index.field(field.getName(), field.getOptions());
@@ -101,8 +101,8 @@ public class Schema {
                 result.indexes.put(indexName, new Index(indexEntry.getValue()));
             } else {
                 // the index exists in the other schema; check the fields
-                Index resultIndex = Index.create(indexName);
                 Index otherIndex = other.indexes.get(indexName);
+                Index resultIndex = Index.create(indexName, otherIndex.getOptions());
                 Map<String, Field> otherIndexFields = otherIndex.getFields();
                 for (Map.Entry<String, Field> fieldEntry : index.getFields().entrySet()) {
                     String fieldName = fieldEntry.getKey();

--- a/com.pilosa.client/src/main/java/com/pilosa/client/status/IndexInfo.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/status/IndexInfo.java
@@ -35,6 +35,7 @@
 package com.pilosa.client.status;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pilosa.client.orm.IndexOptions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +62,12 @@ public class IndexInfo {
         this.fields = fields;
     }
 
+    @JsonProperty("options")
+    public IndexOptions getIndexOptions(){
+        return this.indexOptions;
+    }
+
     private String name;
     private List<FieldInfo> fields = new ArrayList<>();
+    private IndexOptions indexOptions;
 }

--- a/com.pilosa.client/src/test/java/com/pilosa/client/orm/SchemaTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/orm/SchemaTest.java
@@ -48,7 +48,8 @@ public class SchemaTest {
         Index index11 = schema1.index("diff-index1");
         index11.field("field1-1");
         index11.field("field1-2");
-        Index index12 = schema1.index("diff-index2");
+        Index index12 = schema1.index("diff-index2",
+            IndexOptions.builder().keys(true).build());
         index12.field("field2-1");
 
         Schema schema2 = Schema.defaultSchema();
@@ -59,7 +60,8 @@ public class SchemaTest {
         Index targetIndex1 = targetDiff12.index("diff-index1");
         targetIndex1.field("field1-1");
         targetIndex1.field("field1-2");
-        Index targetIndex2 = targetDiff12.index("diff-index2");
+        Index targetIndex2 = targetDiff12.index("diff-index2",
+            IndexOptions.builder().keys(true).build());
         targetIndex2.field("field2-1");
 
         Schema diff12 = schema1.diff(schema2);

--- a/com.pilosa.client/src/test/resources/schema1.json
+++ b/com.pilosa.client/src/test/resources/schema1.json
@@ -12,7 +12,10 @@
             "timeQuantum": "YMD"
           }
         }
-      ]
+      ],
+      "options": {
+        "keys": true
+      }
     },
     {
       "name": "mix"


### PR DESCRIPTION
`readSchema` and `syncSchema` calls from the client are currently not setting the index options values retrieved from the server. This causes problems for indices using string keys since the `IndexOptions` values remain as the default values of `false` even after syncing the schema with the server. This change reads in the index options retrieved from the server and sets the values in the `IndexOptions` object of the `Index`.  