### PR TITLE
Fixes and updates

### DIFF
--- a/com.pilosa.client/pom.xml
+++ b/com.pilosa.client/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <!-- conditionally skip unit tests -->
                     <skipTests>${skip.unit.tests}</skipTests>
@@ -253,19 +253,17 @@
 
     </build>
 
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+            </plugin>
+        </plugins>
+    </reporting>
+
     <dependencies>
-        <!--
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.8</version>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -296,11 +294,6 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.6.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.4</version>
         </dependency>
 
         <dependency>

--- a/com.pilosa.client/src/integration-test/java/integrationtest/PilosaClientIT.java
+++ b/com.pilosa.client/src/integration-test/java/integrationtest/PilosaClientIT.java
@@ -644,7 +644,7 @@ public class PilosaClientIT {
     @Test
     public void importRoaringTimeFieldTest() throws IOException {
         try (PilosaClient client = this.getClient()) {
-            RecordIterator iterator = StaticColumnIterator.columnsWithIDs();
+            RecordIterator iterator = StaticColumnIteratorWithTimestamp.columnsWithIDs();
             FieldOptions fieldOptions = FieldOptions.builder()
                     .fieldTime(TimeQuantum.YEAR_MONTH_DAY_HOUR)
                     .build();
@@ -736,14 +736,14 @@ public class PilosaClientIT {
             RecordIterator iterator = StaticColumnIterator.fieldValuesWithKeys();
             FieldOptions options = FieldOptions.builder()
                     .fieldInt(0, 100)
-                    .keys(true)
+                    .setKeys(true)
                     .build();
             Field field = this.keyIndex.field("importvaluefieldkeys", options);
             client.ensureField(field);
             client.importField(field, iterator);
 
             FieldOptions options2 = FieldOptions.builder()
-                    .keys(true)
+                    .setKeys(true)
                     .build();
             Field field2 = this.keyIndex.field("importvaluefieldkeys-set", options2);
             client.ensureField(field2);
@@ -967,25 +967,34 @@ public class PilosaClientIT {
 
     @Test
     public void syncSchemaTest() throws IOException {
-        Index remoteIndex = Index.create("remote-index-1");
-        Field remoteField = remoteIndex.field("remote-field-1");
-        Schema schema1 = Schema.defaultSchema();
-        Index index11 = schema1.index("diff-index1");
-        index11.field("field1-1");
-        index11.field("field1-2");
-        Index index12 = schema1.index("diff-index2");
-        index12.field("field2-1");
-        schema1.index(remoteIndex.getName());
+        Index index = null;
 
         try (PilosaClient client = this.getClient()) {
-            client.ensureIndex(remoteIndex);
-            client.ensureField(remoteField);
-            client.syncSchema(schema1);
+            Schema schema = client.readSchema();
+            IndexOptions indexOptions = IndexOptions.builder()
+                    .setKeys(true)
+                    .setTrackExistence(true)
+                    .build();
+            index = schema.index("index11", indexOptions);
+            FieldOptions fieldOptions = FieldOptions.builder()
+                    .setKeys(true)
+                    .fieldSet(CacheType.RANKED, 50000)
+                    .build();
+            index.field("index11-f1", fieldOptions);
+            client.syncSchema(schema);
+            Schema schema2 = client.readSchema();
+            Index index2 = schema2.index("index11");
+            assertEquals(index, index2);
+            Schema schema3 = Schema.defaultSchema();
+            client.syncSchema(schema3);
+            Index index3 = schema3.index("index11");
+            assertEquals(index, index3);
+
         } finally {
             try (PilosaClient client = this.getClient()) {
-                client.deleteIndex(remoteIndex);
-                client.deleteIndex(index11);
-                client.deleteIndex(index12);
+                if (index != null) {
+                    client.deleteIndex(index);
+                }
             }
         }
     }
@@ -1617,6 +1626,65 @@ class StaticColumnIterator implements RecordIterator {
     }
 
     private StaticColumnIterator(boolean keys, boolean intValues) {
+        this.records = new ArrayList<>(3);
+        if (keys) {
+            if (intValues) {
+                this.records.add(FieldValue.create("ten", 7));
+                this.records.add(FieldValue.create("seven", 1));
+            } else {
+                this.records.add(Column.create("ten", "five"));
+                this.records.add(Column.create("two", "three"));
+                this.records.add(Column.create("seven", "one"));
+            }
+        } else {
+            if (intValues) {
+                this.records.add(FieldValue.create(10, 7));
+                this.records.add(FieldValue.create(7, 1));
+            } else {
+                this.records.add(Column.create(10, 5));
+                this.records.add(Column.create(2, 3));
+                this.records.add(Column.create(7, 1));
+            }
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.index < this.records.size();
+    }
+
+    @Override
+    public Record next() {
+        return this.records.get(index++);
+    }
+
+    @Override
+    public void remove() {
+        // We have this just to avoid compilation problems on JDK 7
+    }
+}
+
+class StaticColumnIteratorWithTimestamp implements RecordIterator {
+    private List<Record> records;
+    private int index = 0;
+
+    public static StaticColumnIteratorWithTimestamp columnsWithIDs() {
+        return new StaticColumnIteratorWithTimestamp(false, false);
+    }
+
+    public static StaticColumnIteratorWithTimestamp columnsWithKeys() {
+        return new StaticColumnIteratorWithTimestamp(true, false);
+    }
+
+    public static StaticColumnIteratorWithTimestamp fieldValuesWithIDs() {
+        return new StaticColumnIteratorWithTimestamp(false, true);
+    }
+
+    public static StaticColumnIteratorWithTimestamp fieldValuesWithKeys() {
+        return new StaticColumnIteratorWithTimestamp(true, true);
+    }
+
+    private StaticColumnIteratorWithTimestamp(boolean keys, boolean intValues) {
         this.records = new ArrayList<>(3);
         if (keys) {
             if (intValues) {

--- a/com.pilosa.client/src/main/java/com/pilosa/client/ClientOptions.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/ClientOptions.java
@@ -132,11 +132,6 @@ public final class ClientOptions {
             return this;
         }
 
-        public Builder setImportThreadCount(int threadCount) {
-            this.importThreadCount = threadCount;
-            return this;
-        }
-
         public Builder setShardWidth(long shardWidth) {
             this.shardWidth = shardWidth;
             return this;
@@ -149,7 +144,7 @@ public final class ClientOptions {
         public ClientOptions build() {
             return new ClientOptions(this.socketTimeout, this.connectTimeout,
                     this.retryCount, this.connectionPoolSizePerRoute, this.connectionPoolTotalSize,
-                    this.sslContext, this.importThreadCount, this.shardWidth);
+                    this.sslContext, this.shardWidth);
         }
 
         private int socketTimeout = 300000;
@@ -198,17 +193,13 @@ public final class ClientOptions {
         return this.sslContext;
     }
 
-    public int getImportThreadCount() {
-        return this.importThreadCount;
-    }
-
     public long getShardWidth() {
         return this.shardWidth;
     }
 
     private ClientOptions(final int socketTimeout, final int connectTimeout, final int retryCount,
                           final int connectionPoolSizePerRoute, final int connectionPoolTotalSize,
-                          final SSLContext sslContext, final int importThreadCount,
+                          final SSLContext sslContext,
                           final long shardWidth) {
         this.socketTimeout = socketTimeout;
         this.connectTimeout = connectTimeout;
@@ -216,7 +207,6 @@ public final class ClientOptions {
         this.connectionPoolSizePerRoute = connectionPoolSizePerRoute;
         this.connectionPoolTotalSize = connectionPoolTotalSize;
         this.sslContext = sslContext;
-        this.importThreadCount = importThreadCount;
         this.shardWidth = shardWidth;
     }
 
@@ -226,6 +216,5 @@ public final class ClientOptions {
     private final int connectionPoolSizePerRoute;
     private final int connectionPoolTotalSize;
     private final SSLContext sslContext;
-    private final int importThreadCount;
     private final long shardWidth;
 }

--- a/com.pilosa.client/src/main/java/com/pilosa/client/CsvFileColumnIterator.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/CsvFileColumnIterator.java
@@ -56,7 +56,7 @@ import java.util.TimeZone;
  * </pre>
  * @see <a href="https://www.pilosa.com/docs/administration/#importing-and-exporting-data/">Importing and Exporting Data</a>
  */
-public class CsvFileColumnIterator implements ColumnIterator {
+public class CsvFileColumnIterator implements RecordIterator {
     private CsvFileColumnIterator(SimpleDateFormat timestampFormat) {
         this.timestampFormat = timestampFormat;
         if (this.timestampFormat != null) {

--- a/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/PilosaClient.java
@@ -350,6 +350,10 @@ public class PilosaClient implements AutoCloseable {
             List<FieldInfo> fields = indexInfo.getFields();
             if (fields != null) {
                 for (IFieldInfo fieldInfo : indexInfo.getFields()) {
+                    // do not read system indexes
+                    if (systemFields.contains(fieldInfo.getName())) {
+                        continue;
+                    }
                     index.field(fieldInfo.getName(), fieldInfo.getOptions());
                 }
             }
@@ -392,6 +396,10 @@ public class PilosaClient implements AutoCloseable {
             } else {
                 Index localIndex = schema.getIndexes().get(indexName);
                 for (Map.Entry<String, Field> fieldEntry : index.getFields().entrySet()) {
+                    // do not read system indexes
+                    if (systemFields.contains(fieldEntry.getKey())) {
+                        continue;
+                    }
                     localIndex.field(fieldEntry.getValue());
                 }
             }
@@ -723,6 +731,8 @@ public class PilosaClient implements AutoCloseable {
                 new BasicHeader("Accept", "application/x-protobuf"),
                 new BasicHeader("PQL-Version", PQL_VERSION)
         };
+
+        systemFields = Collections.singletonList("exists");
     }
 
     private static final ObjectMapper mapper;
@@ -731,6 +741,7 @@ public class PilosaClient implements AutoCloseable {
     private static final int MAX_HOSTS = 10;
     private static final Header[] protobufHeaders;
     private static final Logger logger = LoggerFactory.getLogger("pilosa");
+    private static List<String> systemFields;
     private Cluster cluster;
     private URI currentAddress;
     private CloseableHttpClient client = null;

--- a/com.pilosa.client/src/main/java/com/pilosa/client/orm/FieldOptions.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/orm/FieldOptions.java
@@ -296,9 +296,9 @@ public final class FieldOptions {
             case TIME:
                 options.put("timeQuantum", this.timeQuantum.toString());
         }
-        if (this.keys) {
-            options.put("keys", true);
-        }
+
+        options.put("keys", this.keys);
+
         Map<String, Object> optionsRoot = new HashMap<>(1);
         optionsRoot.put("options", options);
         if (this.extra != null) {

--- a/com.pilosa.client/src/main/java/com/pilosa/client/orm/IndexOptions.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/orm/IndexOptions.java
@@ -90,9 +90,21 @@ public final class IndexOptions {
          *
          * @param enable
          * @return IndexOptions builder
+         * @deprecated
          */
 
         public Builder trackExistence(boolean enable) {
+            this.trackExistence = enable;
+            return this;
+        }
+
+        /**
+         * Enables keeping track of existence which is required for Not query
+         *
+         * @param enable
+         * @return IndexOptions builder
+         */
+        public Builder setTrackExistence(boolean enable) {
             this.trackExistence = enable;
             return this;
         }

--- a/com.pilosa.client/src/main/java/com/pilosa/client/orm/Schema.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/orm/Schema.java
@@ -84,7 +84,7 @@ public class Schema {
      */
     public Index index(Index other) {
         Index index = this.index(other.getName(), other.getOptions());
-        for (Map.Entry<String, Field> fieldEntry : index.getFields().entrySet()) {
+        for (Map.Entry<String, Field> fieldEntry : other.getFields().entrySet()) {
             Field field = fieldEntry.getValue();
             index.field(field.getName(), field.getOptions());
         }

--- a/com.pilosa.client/src/main/java/com/pilosa/client/status/FieldInfo.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/status/FieldInfo.java
@@ -71,12 +71,22 @@ final class FieldMeta {
             case SET:
                 builder = builder.fieldSet(this.cacheType, this.cacheSize);
                 break;
+            case MUTEX:
+                builder = builder.fieldMutex(this.cacheType, this.cacheSize);
+                break;
+            case BOOL:
+                builder = builder.fieldBool();
+                break;
             case INT:
                 builder = builder.fieldInt(this.min, this.max);
                 break;
             case TIME:
                 builder = builder.fieldTime(this.timeQuantum);
+                break;
         }
+
+        builder.setKeys(this.keys);
+
         return builder.build();
     }
 
@@ -115,10 +125,16 @@ final class FieldMeta {
         this.max = max;
     }
 
+    @JsonProperty("keys")
+    void setKeys(boolean keys) {
+        this.keys = keys;
+    }
+
     private TimeQuantum timeQuantum = TimeQuantum.NONE;
     private CacheType cacheType = CacheType.DEFAULT;
     private int cacheSize = 0;
     private FieldType fieldType = FieldType.DEFAULT;
     private long min = 0;
     private long max = 0;
+    private boolean keys = false;
 }

--- a/com.pilosa.client/src/test/java/com/pilosa/client/ClientOptionsTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/ClientOptionsTest.java
@@ -68,7 +68,6 @@ public class ClientOptionsTest {
                 .setSslContext(sslContext)
                 .setSkipVersionCheck()
                 .setLegacyMode(true)
-                .setImportThreadCount(2)
                 .setShardWidth(1024)
                 .build();
         assertEquals(2, options.getConnectionPoolSizePerRoute());
@@ -77,7 +76,6 @@ public class ClientOptionsTest {
         assertEquals(1000, options.getSocketTimeout());
         assertEquals(5, options.getRetryCount());
         assertEquals(sslContext, options.getSslContext());
-        assertEquals(2, options.getImportThreadCount());
         assertEquals(1024, options.getShardWidth());
     }
 }

--- a/com.pilosa.client/src/test/java/com/pilosa/client/orm/FieldOptionsTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/orm/FieldOptionsTest.java
@@ -65,14 +65,14 @@ public class FieldOptionsTest {
                 .fieldSet(CacheType.RANKED)
                 .build();
         compare(options, FieldType.SET, TimeQuantum.NONE, CacheType.RANKED, 0, 0, 0);
-        target = "{\"options\":{\"type\":\"set\",\"cacheType\":\"ranked\"}}";
+        target = "{\"options\":{\"keys\":false,\"type\":\"set\",\"cacheType\":\"ranked\"}}";
         assertArrayEquals(stringToSortedChars(target), stringToSortedChars(options.toString()));
 
         options = FieldOptions.builder()
                 .fieldSet()
                 .build();
         compare(options, FieldType.SET, TimeQuantum.NONE, CacheType.DEFAULT, 0, 0, 0);
-        target = "{\"options\":{\"type\":\"set\"}}";
+        target = "{\"options\":{\"keys\":false,\"type\":\"set\"}}";
         assertArrayEquals(stringToSortedChars(target), stringToSortedChars(options.toString()));
     }
 
@@ -82,7 +82,7 @@ public class FieldOptionsTest {
                 .fieldInt(-100, 500)
                 .build();
         compare(options, FieldType.INT, TimeQuantum.NONE, CacheType.DEFAULT, 0, -100, 500);
-        String target = "{\"options\":{\"type\":\"int\",\"min\":-100,\"max\":500}}";
+        String target = "{\"options\":{\"keys\":false,\"type\":\"int\",\"min\":-100,\"max\":500}}";
         assertArrayEquals(stringToSortedChars(target), stringToSortedChars(options.toString()));
     }
 
@@ -92,7 +92,7 @@ public class FieldOptionsTest {
                 .fieldTime(TimeQuantum.MONTH_DAY_HOUR)
                 .build();
         compare(options, FieldType.TIME, TimeQuantum.MONTH_DAY_HOUR, CacheType.DEFAULT, 0, 0, 0);
-        String target = "{\"options\":{\"type\":\"time\",\"timeQuantum\":\"MDH\"}}";
+        String target = "{\"keys\":false,\"options\":{\"type\":\"time\",\"timeQuantum\":\"MDH\"}}";
         assertArrayEquals(stringToSortedChars(target), stringToSortedChars(options.toString()));
     }
 
@@ -103,7 +103,7 @@ public class FieldOptionsTest {
 
         options = FieldOptions.builder()
                 .fieldMutex(CacheType.RANKED, 1000)
-                .keys(true)
+                .setKeys(true)
                 .build();
         compare(options, FieldType.MUTEX, TimeQuantum.NONE, CacheType.RANKED, 1000, 0, 0);
         target = "{\"options\":{\"keys\":true,\"type\":\"mutex\",\"cacheSize\":1000,\"cacheType\":\"ranked\"}}";
@@ -113,14 +113,14 @@ public class FieldOptionsTest {
                 .fieldMutex(CacheType.RANKED)
                 .build();
         compare(options, FieldType.MUTEX, TimeQuantum.NONE, CacheType.RANKED, 0, 0, 0);
-        target = "{\"options\":{\"type\":\"mutex\",\"cacheType\":\"ranked\"}}";
+        target = "{\"options\":{\"keys\":false,\"type\":\"mutex\",\"cacheType\":\"ranked\"}}";
         assertArrayEquals(stringToSortedChars(target), stringToSortedChars(options.toString()));
 
         options = FieldOptions.builder()
                 .fieldMutex()
                 .build();
         compare(options, FieldType.MUTEX, TimeQuantum.NONE, CacheType.DEFAULT, 0, 0, 0);
-        target = "{\"options\":{\"type\":\"mutex\"}}";
+        target = "{\"keys\":false,\"options\":{\"type\":\"mutex\"}}";
         assertArrayEquals(stringToSortedChars(target), stringToSortedChars(options.toString()));
     }
 
@@ -130,7 +130,7 @@ public class FieldOptionsTest {
                 .fieldBool()
                 .build();
         compare(options, FieldType.BOOL, TimeQuantum.NONE, CacheType.DEFAULT, 0, 0, 0);
-        String target = "{\"options\":{\"type\":\"bool\"}}";
+        String target = "{\"keys\":false,\"options\":{\"type\":\"bool\"}}";
         assertArrayEquals(stringToSortedChars(target), stringToSortedChars(options.toString()));
     }
 
@@ -138,7 +138,7 @@ public class FieldOptionsTest {
     @Test
     public void testKeysOption() {
         FieldOptions options = FieldOptions.builder()
-                .keys(true)
+                .setKeys(true)
                 .build();
         assertTrue(options.isKeys());
     }


### PR DESCRIPTION
- Fixes loading field keys with syncSchema
- Moves maven javadoc dep out of dependencies to `reportin` section
- Removes import options from `ClientOptions` (they are still available in `ImportOptions`)
- `CsvFileColumnIterator` implements `RecordIterator`