### PR TITLE
Ensure dates are always formatted for UTC timezone

### DIFF
--- a/com.pilosa.client/src/main/java/com/pilosa/client/orm/Field.java
+++ b/com.pilosa.client/src/main/java/com/pilosa/client/orm/Field.java
@@ -45,6 +45,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
+import java.util.TimeZone;
 
 /**
  * Fields are used to segment and define different functional characteristics within your entire index.
@@ -1097,8 +1098,14 @@ public class Field {
                 fmtDate.format(toTimestamp), fmtTime.format(toTimestamp));
     }
 
-    private final static DateFormat fmtDate = new SimpleDateFormat("yyyy-MM-dd");
-    private final static DateFormat fmtTime = new SimpleDateFormat("HH:mm");
+    private static DateFormat utcDateFormat(String format) {
+        DateFormat fmt = new SimpleDateFormat(format);
+        fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return fmt;
+    }
+
+    private final static DateFormat fmtDate = utcDateFormat("yyyy-MM-dd");
+    private final static DateFormat fmtTime =  utcDateFormat("HH:mm");
     private String name;
     private Index index;
     private FieldOptions options;

--- a/com.pilosa.client/src/test/java/com/pilosa/client/orm/OrmTest.java
+++ b/com.pilosa.client/src/test/java/com/pilosa/client/orm/OrmTest.java
@@ -41,6 +41,7 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Calendar;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.TreeMap;
 
 import static org.junit.Assert.assertEquals;
@@ -127,9 +128,9 @@ public class OrmTest {
                 "Row(collaboration=true)",
                 q.serialize().getQuery());
 
-        Calendar start = Calendar.getInstance();
+        Calendar start = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         start.set(1970, Calendar.JANUARY, 1, 0, 0);
-        Calendar end = Calendar.getInstance();
+        Calendar end = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         end.set(2000, Calendar.FEBRUARY, 2, 3, 4);
 
         q = collabField.row("ten", start.getTime(), end.getTime());
@@ -207,7 +208,7 @@ public class OrmTest {
 
     @Test
     public void setWithTimestampTest() {
-        Calendar timestamp = Calendar.getInstance();
+        Calendar timestamp = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         timestamp.set(2017, Calendar.APRIL, 24, 12, 14);
         PqlQuery q = collabField.set(10, 20, timestamp.getTime());
         assertEquals(
@@ -414,9 +415,9 @@ public class OrmTest {
 
     @Test
     public void rangeTest() {
-        Calendar start = Calendar.getInstance();
+        Calendar start = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         start.set(1970, Calendar.JANUARY, 1, 0, 0);
-        Calendar end = Calendar.getInstance();
+        Calendar end = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         end.set(2000, Calendar.FEBRUARY, 2, 3, 4);
         PqlBaseQuery q = collabField.range(10, start.getTime(), end.getTime());
         assertEquals(


### PR DESCRIPTION
When converting from an `Instant` to a `Date`, if the date is formatted without specifying the timezone it will use the current system timezone. The Pilosa server seems to expect timestamps offset at UTC so this ensures that whatever zone the local machine is in time ranges will always be sent in UTC.

- update `Field` to format dates in UTC
- ensure calendars in tests are set to UTC